### PR TITLE
OpenRTB 3.0: removed undocumented hb and fd fields from Bid Request example

### DIFF
--- a/OpenRTB 3.0 BETA.md
+++ b/OpenRTB 3.0 BETA.md
@@ -1201,8 +1201,6 @@ The following is an example of Layer-3 of a bid request with a single item offer
 			"cur": [ "USD", "EUR" ],
 			"source": {
 				"ds": "AE23865DF890100BECCD76579DD4769DBBA9812CEE8ED90BF",
-				"hb": 1,
-				"fd": 1,
 				"tid": "FEDCBA9876543210",
 				"pchain": "..."
 			},


### PR DESCRIPTION
Any extra fields, not mentioned in spec itself, are misleading in examples.
Looks more like a bad/excess copypaste or some work-in-progress remnants.
Change suggested in https://github.com/InteractiveAdvertisingBureau/openrtb/issues/9