### PR TITLE
Fix SupplyChain object examples to use "schain".

### DIFF
--- a/supplychainobject.md
+++ b/supplychainobject.md
@@ -111,7 +111,7 @@ Examples:
   }
   "source": {
     "ext": {
-      "supplychain": {
+      "schain": {
         "complete": 1,
         "nodes": [
           {
@@ -139,7 +139,7 @@ Sample resale of BidRequest1 (BidRequest2, seller = "reseller.com"):
   }
   "source": {
     "ext": {
-      "supplychain": {
+      "schain": {
         "complete": 1,
         "nodes": [
           {
@@ -192,7 +192,7 @@ Sample resale of BidRequest3 by advertising system that does support SupplyChain
   }
   "source": {
     "ext": {
-      "supplychain": {
+      "schain": {
         "complete": 0,
         "nodes": [
           {


### PR DESCRIPTION
The documentation says, "The SupplyChain object should be included in the BidRequest.Source.ext.schain attribute in OpenRTB 2.5 or later," however it uses "supplychain" in the examples. This PR changes the examples to be consistent with the documentation.