### PR TITLE
Attempts to make language more understandable

### DIFF
--- a/OpenRTB v3.0 FINAL.md
+++ b/OpenRTB v3.0 FINAL.md
@@ -216,7 +216,7 @@ The OpenRTB version must be passed in the header of a bid request with a custom 
 
 `x-openrtb-version: 3.0`
 
-Additionally, it is recommended albeit optional that responses include an identically formatted HTTP header with the protocol version implemented by the responder.  It is assumed, however, that any response will be compatible with the version of the request and that version support is discussed *a priori* between the parties.
+Additionally, it is recommended albeit optional that responses include an identically formatted HTTP header with the protocol version implemented by the responder.  It is assumed, however, that any response will be compatible with the version of the request and that version support is discussed beforehand between the parties.
 
 **BEST PRACTICE:**  One of the simplest and most effective ways of improving connection performance is to enable HTTP Persistent Connections, also known as Keep-Alive.  This has a profound impact on overall performance by reducing connection management overhead as well as CPU utilization on both sides of the interface.
 
@@ -374,7 +374,7 @@ The `Request` object contains a globally unique bid request ID. This `id` attrib
   <tr>
     <td><code>seat</code></td>
     <td>string&nbsp;array</td>
-    <td>Restriction list of buyer seats for bidding on this item.  Knowledge of buyer’s customers and their seat IDs must be coordinated between parties <em>a priori</em>. Omission implies no restrictions.</td>
+    <td>Restriction list of buyer seats for bidding on this item.  Knowledge of buyer’s customers and their seat IDs must be coordinated between parties beforehand. Omission implies no restrictions.</td>
   </tr>
   <tr>
     <td><code>wseat</code></td>
@@ -553,7 +553,7 @@ For AdCOM v1.x, the objects allowed here are <code>Placement</code> and any obje
 
 ### Object:  Deal <a name="object_deal"></a>
 
-This object constitutes a specific deal that was struck *a priori* between a seller and a buyer.  Its presence indicates that this item is available under the terms of that deal.
+This object constitutes a specific deal that was struck in advance between a seller and a buyer.  Its presence indicates that this item is available under the terms of that deal.
 
 <table>
   <tr>


### PR DESCRIPTION
So, there a few problems with the usage of *a priori* here:

- it's a term that's not widely known/understood; is this language complication really necessary here, if you could use simpler and more universal language instead?
- more importantly, it's usage here is incorrect; *a priori* implies knowledge that can be derived without additional data, e.g. "all husbands are male"; in most of your uses, you simply mean "ahead of time" or "beforehand"