### PR TITLE
Fix oversights for DOOH

### DIFF
--- a/OpenRTB v3.0 FINAL.md
+++ b/OpenRTB v3.0 FINAL.md
@@ -477,7 +477,12 @@ This object represents a unit of goods being offered for sale either on the open
   <tr>
     <td><code>qty</code></td>
     <td>integer;<br/>default&nbsp;1</td>
-    <td>The number of instances (i.e., “quantity”) of this item being offered (e.g., multiple identical impressions in a digital out-of-home scenario).</td>
+    <td>The quantity of billable events which will be deemed to have occured if this item is purchased. In most cases, this represents impressions. For example, a single display of an ad on a DOOH placement may count as multiple impressions on the basis of expected viewership. In such a case, qty would be greater than 1. Only one of 'qty' or 'qtyflt' may be present.</td>
+  </tr>
+    <tr>
+    <td><code>qtyflt</code></td>
+    <td>float</td>
+    <td>The quantity of billable events which will be deemed to have occured if this item is purchased. This version of the fields exists for cases where the quantity is not expressed as a whole number. For example, a DOOH opportunity may be considered to be 14.2 impressions. Only one of 'qty' or 'qtyflt' may be present. </td>
   </tr>
   <tr>
     <td><code>seq</code></td>
@@ -846,6 +851,10 @@ The following table defines the standard substitution macros.  Note that OpenRTB
   <tr>
     <td><code>${OPENRTB_ITEM_ID}</code></td>
     <td>ID of the item just won; from <code>item.id</code> attribute.</td>
+  </tr>
+  <tr>
+    <td><code>${OPENRTB_ITEM_QTY}</code></td>
+    <td>Quantity of the item just won; from <code>item.qty</code> or <code>item.qtyflt</code> attribute.</td>
   </tr>
   <tr>
     <td><code>${OPENRTB_SEAT_ID}</code></td>


### PR DESCRIPTION
Due to oversight, initial release of OpenRTB 3.0 did not support non-integer quantities. In practice, in DOOH, non-integer quantities of impressions are routinely transacted. Thus, the DOOH support is not adequate for transacting for many companies at this time. 

It would be a breaking change to modify the type of the 'qty' field and this wouldn't be allowed without iterating the OpenRTB version number. As it doesn't seem warranted to make a breaking change for this, instead I propose a 'qtyflt' field.

I have also added a macro to communicate the quantity (common for DOOH implementations; this is useful in the case where the bidder wants to know the quantity on receipt of billing notice and does not intend to store the original bid request and look up the quantity from it).

Finally, I have rephrased the definition of qty in the hopes of making it clearer. Previously, it could be misunderstood to fill the role of the 'plcmntcnt' field in OpenRTB Native; in other words, it could be misunderstood that the Item object was representing x identical items for which multiple bids could be submitted, and multiple bids could win.

That is not the case; rather, this is intended for the DOOH case. It is the same as 'impmultiply' in the DPAA spec. Item represents an indivisible transaction -- if you buy the item, you have bought something which counts as X billable events. In practice, 'billable events' means impressions, but I don't think the spec should prescribe that. The point is, cannot be subdivided and purchased in part with multiple different bids and ads.