### PR TITLE
Add some json schemas

### DIFF
--- a/schemas/openrtb-schema_bid-request_v1-0.json
+++ b/schemas/openrtb-schema_bid-request_v1-0.json
@@ -1,0 +1,324 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_0-schema-bid_request",
+	"description": "json schema for an openrtb v1.0 bid request (http://openrtb.googlecode.com/files/OpenRTB%20Mobile%20RTB%20API%20-%201.0.pdf)",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"properties": {
+		"id": {
+		    "$ref": "#/definitions/string_40"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"imp": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"restrictions": {
+			"$ref": "#/definitions/restrictions"
+		}
+	},
+    "definitions": {
+		"imp": {
+	        "type": "object",
+			"required": [ "impid" ],
+			"properties": {
+				"impid": {
+				    "$ref": "#/definitions/string_40"
+				},
+				"wseat": {
+				    "type": "array"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"properties": {
+				"sid": {
+					"$ref": "#/definitions/string_40"
+				},
+				"name": {
+					"$ref": "#/definitions/string_64"
+				},
+				"domain": {
+					"$ref": "#/definitions/string_64"
+				},
+				"pid": {
+					"$ref": "#/definitions/string_40"
+				},
+				"pub": {
+					"$ref": "#/definitions/string_64"
+				},
+				"pdomain": {
+					"$ref": "#/definitions/string_64"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"keywords": {
+					"$ref": "#/definitions/string_256"
+				},
+				"page": {
+					"$ref": "#/definitions/string_256"
+				},
+				"ref": {
+					"$ref": "#/definitions/string_256"
+				},
+				"search": {
+					"$ref": "#/definitions/string_256"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"properties": {
+				"aid": {
+					"$ref": "#/definitions/string_40"
+				},
+				"name": {
+					"$ref": "#/definitions/string_64"
+				},
+				"domain": {
+					"$ref": "#/definitions/string_64"
+				},
+				"pid": {
+					"$ref": "#/definitions/string_40"
+				},
+				"pub": {
+					"$ref": "#/definitions/string_64"
+				},
+				"pdomain": {
+					"$ref": "#/definitions/string_64"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"keywords": {
+					"$ref": "#/definitions/string_256"
+				},
+				"ver": {
+					"$ref": "#/definitions/string_16"
+				},
+				"bundle": {
+					"$ref": "#/definitions/string_64"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"properties": {
+				"did": {
+					"$ref": "#/definitions/string_42"
+				},
+				"dpid": {
+					"$ref": "#/definitions/string_42"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"country": {
+					"$ref": "#/definitions/country"
+				},
+				"carrier": {
+					"$ref": "#/definitions/string_64"
+				},
+				"ua": {
+					"$ref": "#/definitions/string_256"
+				},
+				"make": {
+					"$ref": "#/definitions/string_32"
+				},
+				"model": {
+					"$ref": "#/definitions/string_32"
+				},
+				"os": {
+					"$ref": "#/definitions/string_32"
+				},
+				"osv": {
+					"$ref": "#/definitions/string_32"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"loc": {
+					"$ref": "#/definitions/string_16"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"properties": {
+				"uid": {
+					"$ref": "#/definitions/string_40"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"zip": {
+					"$ref": "#/definitions/string_16"
+				},
+				"country": {
+					"$ref": "#/definitions/country"
+				},
+				"keywords": {
+					"$ref": "#/definitions/string_256"
+				}
+			}
+		},
+		"restrictions": {
+			"type": "object",
+			"properties": {
+				"bcat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"badv": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			}
+		},
+
+
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB2", "IAB3", "IAB4", "IAB5", "IAB6", "IAB7", "IAB8", "IAB9", "IAB10", "IAB11", "IAB12", "IAB13",
+				"IAB14", "IAB15", "IAB16", "IAB17", "IAB18", "IAB19", "IAB20", "IAB21", "IAB22", "IAB23", "IAB24", "IAB25", "IAB26"
+			]
+		},
+		"ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 14
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"country": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 4
+		},
+		"string_16": {
+		    "type": "string",
+		    "maxLength": 16
+		},
+		"string_32": {
+		    "type": "string",
+		    "maxLength": 32
+		},
+		"string_40": {
+		    "type": "string",
+		    "maxLength": 40
+		},
+		"string_42": {
+		    "type": "string",
+		    "maxLength": 42
+		},
+		"string_64": {
+		    "type": "string",
+		    "maxLength": 64
+		},
+		"string_256": {
+		    "type": "string",
+		    "maxLength": 256
+		}
+	}
+}

--- a/schemas/openrtb-schema_bid-request_v2-0.json
+++ b/schemas/openrtb-schema_bid-request_v2-0.json
@@ -1,0 +1,786 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_0-schema-bid_request",
+	"description": "json schema for an openrtb v2.0 bid request (http://www.iab.net/media/file/OpenRTB_API_Specification_Version2.0_FINAL.PDF)",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "type": "string"
+		},
+		"imp": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+    "definitions": {
+		"imp": {
+	        "type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+				    "type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"displaymanager": {
+				    "type": "string"
+				},
+				"displaymanagerver": {
+				    "type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+				    "type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				}
+			}
+		},
+		"video": {
+	        "type": "object",
+			"required": [ "mimes", "linearity", "minduration", "maxduration", "protocol" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"videoquality": {
+					"$ref": "#/definitions/video_quality"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ua": {
+					"type": "string"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"flashver": {
+					"type": "string"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				}
+			}
+		},
+
+
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 6
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2,
+			"maximum": 0
+		},
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"content_context": {
+			"type": "string",
+			"enum": [
+				"1", "2", "3", "4", "5", "6", "7"
+			]
+		},
+		"video_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 3,
+		    "pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_v2-1.json
+++ b/schemas/openrtb-schema_bid-request_v2-1.json
@@ -1,0 +1,848 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_1-schema-bid_request",
+	"description": "json schema for an openrtb v2.1 bid request (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-1-FINAL.pdf)",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "type": "string"
+		},
+		"imp": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+    "definitions": {
+		"imp": {
+	        "type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+				    "type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"displaymanager": {
+				    "type": "string"
+				},
+				"displaymanagerver": {
+				    "type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+				    "type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+	        "type": "object",
+			"required": [ "mimes", "linearity", "minduration", "maxduration", "protocol" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"$ref": "#/definitions/vast_companion_type"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"videoquality": {
+					"$ref": "#/definitions/video_quality"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ua": {
+					"type": "string"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"flashver": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 6
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2,
+			"maximum": 0
+		},
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"content_context": {
+			"type": "string",
+			"enum": [
+				"1", "2", "3", "4", "5", "6", "7"
+			]
+		},
+		"video_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 3,
+		    "pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_v2-2.json
+++ b/schemas/openrtb-schema_bid-request_v2-2.json
@@ -1,0 +1,951 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_2-schema-bid_request",
+	"description": "json schema for an openrtb v2.2 bid request",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "type": "string"
+		},
+		"imp": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+        "regs": {
+            "$ref": "#/definitions/regs"
+        },
+		"ext": {
+			"type": "object"
+		}
+	},
+    "definitions": {
+		"imp": {
+	        "type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+				    "type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"displaymanager": {
+				    "type": "string"
+				},
+				"displaymanagerver": {
+				    "type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+				    "type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"secure": {
+				   "$ref": "#/definitions/boolean_int"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+                "pmp": {
+                    "$ref": "#/definitions/pmp"
+                },
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+                "wmax": {
+                    "$ref": "#/definitions/positive_int"
+                },
+                "hmax": {
+                    "$ref": "#/definitions/positive_int"
+                },
+                "wmin": {
+                    "$ref": "#/definitions/positive_int"
+                },
+                "hmin": {
+                    "$ref": "#/definitions/positive_int"
+                },
+				"id": {
+					"type": "string"
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+	        "type": "object",
+            "required": [ "mimes", "minduration", "maxduration" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"
+					}
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+                    "items": {
+    					"$ref": "#/definitions/vast_companion_type"
+                    }
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"videoquality": {
+					"$ref": "#/definitions/video_quality"
+				},
+				"keywords": {
+                    "type": "string"
+                },
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ua": {
+					"type": "string"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+                "macsha1": {
+                    "type": "string"
+                },
+                "macmd5": {
+                    "type": "string"
+                },
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"flashver": {
+					"type": "string"
+				},
+                "ifa": {
+                    "type": "string"
+                },
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+        "regs": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "coppa": {
+                    "$ref": "#/definitions/boolean_int"
+                },
+                "ext": {
+                    "type": "object"
+                }
+            }
+        },
+        "pmp": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "private_auction": {
+                    "$ref": "#/definitions/boolean_int"
+                },
+                "deals": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/deal"
+					}
+                },
+                "ext": {
+                    "type": "object"
+                }
+            }
+        },
+        "deal": {
+            "type": "object",
+            "required": [ "id" ],
+            "additionalProperties": false,
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "bidfloor": {
+                    "type": "number",
+                    "minimum": 0
+                },
+                "bidfloorcur": {
+                   "$ref": "#/definitions/currency"
+                },
+                "wseat": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "wadomain": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "at": {
+                    "type": "integer"
+                },
+                "ext": {
+                    "type": "object"
+                }
+            }
+        },
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 6
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2,
+			"maximum": 0
+		},
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"content_context": {
+			"type": "string",
+			"enum": [
+				"1", "2", "3", "4", "5", "6", "7"
+			]
+		},
+		"video_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 3,
+		    "pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_v2-3.json
+++ b/schemas/openrtb-schema_bid-request_v2-3.json
@@ -1,0 +1,1012 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_3-schema-bid_request",
+	"description": "json schema for an openrtb v2.3 bid request",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"imp": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"test": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"regs": {
+			"$ref": "#/definitions/regs"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"imp": {
+			"type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				},
+				{
+					"required": [
+						"native"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"native": {
+					"$ref": "#/definitions/native"
+				},
+				"displaymanager": {
+					"type": "string"
+				},
+				"displaymanagerver": {
+					"type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"secure": {
+				   "$ref": "#/definitions/boolean_int"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"pmp": {
+					"$ref": "#/definitions/pmp"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"
+					}
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/vast_companion_type"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"native": {
+			"type": "object",
+			"required": [ "request" ],
+			"additionalProperties": false,
+			"properties": {
+				"request": {
+					"type": "string"
+				},
+				"ver": {
+					"type": "string"
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"mobile": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"videoquality": {
+					"$ref": "#/definitions/video_quality"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ua": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"lmt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"hwv": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ppi": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"pxratio": {
+					"type": "number"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"flashver": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"ifa": {
+					"type": "string"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"macsha1": {
+					"type": "string"
+				},
+				"macmd5": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"utcoffset": {
+					"type": "integer"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"regs": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"coppa": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"pmp": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"private_auction": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"deals": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/deal"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"deal": {
+			"type": "object",
+			"required": [ "id" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"at": {
+					"type": "integer"
+				},
+				"wseat": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"wadomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},		
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 6
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2
+		},
+		"video_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"content_context": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},		
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_v2-4.json
+++ b/schemas/openrtb-schema_bid-request_v2-4.json
@@ -1,0 +1,1196 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_4-schema-bid_request",
+	"description": "json schema for an openrtb v2.4 bid request",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"imp": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"test": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"bapp": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"regs": {
+			"$ref": "#/definitions/regs"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"imp": {
+			"type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				},
+				{
+					"required": [
+					    "audio"
+					]
+				},
+				{
+					"required": [
+						"native"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"audio": {
+					"$ref": "#/definitions/audio"
+				},
+				"native": {
+					"$ref": "#/definitions/native"
+				},
+				"displaymanager": {
+					"type": "string"
+				},
+				"displaymanagerver": {
+					"type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"clickbrowser": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"secure": {
+				   "$ref": "#/definitions/boolean_int"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"pmp": {
+					"$ref": "#/definitions/pmp"
+				},
+				"exp": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"format": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/format"
+					}
+				},
+				"wmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"
+					}
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"skip": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"skipmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"skipafter": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/vast_companion_type"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"audio": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"	
+					}
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#definitions/vast_companion_type"
+					}
+				},
+				"maxseq": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"feed": {
+					"$ref": "#/definitions/audio_feed_type"
+				},
+				"stitched": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"nvol": {
+					"$ref": "#/definitions/volume_normalization_mode"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"native": {
+			"type": "object",
+			"required": [ "request" ],
+			"additionalProperties": false,
+			"properties": {
+				"request": {
+					"type": "string"
+				},
+				"ver": {
+					"type": "string"
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"format": {
+			"type": "object",
+			"description": "represents an allowed size for a banner impression",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+						"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+						"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"mobile": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"artist": {
+					"type": "string"
+				},
+				"genre": {
+					"type": "string"
+				},
+				"album": {
+					"type": "string"
+				},
+				"isrc": {
+					"type": "string"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"prodq": {
+					"$ref": "#/definitions/production_quality"
+				},
+				"videoquality": {
+					"$ref": "#/definitions/production_quality"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ua": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"lmt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"hwv": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ppi": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"pxratio": {
+					"type": "number"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"geofetch": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"flashver": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"ifa": {
+					"type": "string"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"macsha1": {
+					"type": "string"
+				},
+				"macmd5": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"accuracy": {
+					"type": "integer"
+				},
+				"lastfix": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ipservice": {
+					"$ref": "#/definitions/ip_location_services"
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"utcoffset": {
+					"type": "integer"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"regs": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"coppa": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"pmp": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"private_auction": {
+					"$ref": "#/definitions/boolean_int",
+					"default": 0
+				},
+				"deals": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/deal"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"deal": {
+			"type": "object",
+			"required": [ "id" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"at": {
+					"type": "integer"
+				},
+				"wseat": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"wadomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 17
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},		
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 10
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2
+		},
+		"production_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_context": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},		
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		},
+		"audio_feed_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"ip_location_services": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"volume_normalization_mode": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 4
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_with_factual_v2-3.json
+++ b/schemas/openrtb-schema_bid-request_with_factual_v2-3.json
@@ -1,0 +1,1066 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_3-schema-bid_request",
+	"description": "json schema for an openrtb v2.3 bid request",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"imp": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"test": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/factual_content_category"
+			}
+		},
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"regs": {
+			"$ref": "#/definitions/regs"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"imp": {
+			"type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				},
+				{
+					"required": [
+						"native"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"native": {
+					"$ref": "#/definitions/native"
+				},
+				"displaymanager": {
+					"type": "string"
+				},
+				"displaymanagerver": {
+					"type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"secure": {
+				   "$ref": "#/definitions/boolean_int"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"pmp": {
+					"$ref": "#/definitions/pmp"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"
+					}
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/vast_companion_type"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"native": {
+			"type": "object",
+			"required": [ "request" ],
+			"additionalProperties": false,
+			"properties": {
+				"request": {
+					"type": "string"
+				},
+				"ver": {
+					"type": "string"
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"mobile": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"videoquality": {
+					"$ref": "#/definitions/video_quality"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ua": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"lmt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"hwv": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ppi": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"pxratio": {
+					"type": "number"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"flashver": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"ifa": {
+					"type": "string"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"macsha1": {
+					"type": "string"
+				},
+				"macmd5": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"utcoffset": {
+					"type": "integer"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"regs": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"coppa": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"pmp": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"private_auction": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"deals": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/deal"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"deal": {
+			"type": "object",
+			"required": [ "id" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"at": {
+					"type": "integer"
+				},
+				"wseat": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"wadomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		
+		"factual_content_category": {
+			"type": "string",
+			"enum": [
+				"1","2","3","4","5","6","7","8","9","10",
+				"11","12","13","14","15","16","17","18","19","20",
+				"21","22","23","24","25","26","27","28","29","30",
+				"31","32","33","34","35","36","37","38","39","40",
+				"41","42","43","44","45","46","47","48","49","50",
+				"51","52","53","54","55","56","57","58","59","60",
+				"61","62","63","64","65","66","67","68","69","70",
+				"71","72","73","74","75","76","77","78","79","80",
+				"81","82","83","84","85","86","87","88","89","90",
+				"91","92","93","94","95","96","97","98","99","100",
+				"101","102","103","104","105","106","107","108","109","110",
+				"111","112","113","114","115","116","117","118","119","120",
+				"121","122","123","124","125","126","127","128","129","130",
+				"131","132","133","134","135","136","137","138","139","140",
+				"141","142","143","144","145","146","147","148","149","150",
+				"151","152","153","154","155","156","157","158","159","160",
+				"161","162","163","164","165","166","167","168","169","170",
+				"171","172","173","174","175","176","177","178","179","180",
+				"181","182","183","184","185","186","187","188","189","190",
+				"191","192","193","194","195","196","197","198","199","200",
+				"201","202","203","204","205","206","207","208","209","210",
+				"211","212","213","214","215","216","217","218","219","220",
+				"221","222","223","224","225","226","227","228","229","230",
+				"231","232","233","234","235","236","237","238","239","240",
+				"241","242","243","244","245","246","247","248","249","250",
+				"251","252","253","254","255","256","257","258","259","260",
+				"261","262","263","264","265","266","267","268","269","270",
+				"271","272","273","274","275","276","277","278","279","280",
+				"281","282","283","284","285","286","287","288","289","290",
+				"291","292","293","294","295","296","297","298","299","300",
+				"301","302","303","304","305","306","307","308","309","310",
+				"311","312","313","314","315","316","317","318","319","320",
+				"321","322","323","324","325","326","327","328","329","330",
+				"331","332","333","334","335","336","337","338","339","340",
+				"341","342","343","344","345","346","347","348","349","350",
+				"351","352","353","354","355","356","357","358","359","360",
+				"361","362","363","364","365","366","367","368","369","370",
+				"371","372","373","374","375","376","377","378","379","380",
+				"381","382","383","384","385","386","387","388","389","390",
+				"391","392","393","394","395","396","397","398","399","400",
+				"401","402","403","404","405","406","407","408","409","410",
+				"411","412","413","414","415","416","417","418","419","420",
+				"421","422","423","424","425","426","427","428","429","430",
+				"431","432","433","434","435","436","437","438","439","440",
+				"441","442","443","444","445","446","447","448","449","450",
+				"451","452","453","454","455","456","457","458","459","460",
+				"461","462","463","464","465","466"
+			]
+		},
+		
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},		
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 6
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2
+		},
+		"video_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"content_context": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},		
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-request_with_factual_v2-4.json
+++ b/schemas/openrtb-schema_bid-request_with_factual_v2-4.json
@@ -1,0 +1,1250 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_4-schema-bid_request",
+	"description": "json schema for an openrtb v2.4 bid request",
+	"type": "object",
+	"required": [ "id", "imp" ],
+	"not": {
+		"allOf": [
+			{
+				"required": [
+					"site"
+				]
+			},
+			{
+				"required": [
+					"app"
+				]
+			}
+		]
+	},
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"imp": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/imp"
+			}
+		},
+		"site": {
+			"$ref": "#/definitions/site"
+		},
+		"app": {
+			"$ref": "#/definitions/app"
+		},
+		"device": {
+			"$ref": "#/definitions/device"
+		},
+		"user": {
+			"$ref": "#/definitions/user"
+		},
+		"test": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"at": {
+			"type": "integer"
+		},
+		"tmax": {
+			"$ref": "#/definitions/positive_int"
+		},
+		"wseat": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"allimps": {
+			"$ref": "#/definitions/boolean_int"
+		},
+		"cur": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/currency"
+			}
+		},
+		"bcat": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/factual_content_category"
+			}
+		},
+		
+		"badv": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"bapp": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"regs": {
+			"$ref": "#/definitions/regs"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"imp": {
+			"type": "object",
+			"required": [ "id" ],
+			"anyOf": [
+				{
+					"required": [
+						"banner"
+					]
+				},
+				{
+					"required": [
+						"video"
+					]
+				},
+				{
+					"required": [
+					    "audio"
+					]
+				},
+				{
+					"required": [
+						"native"
+					]
+				}
+			],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"banner": {
+					"$ref": "#/definitions/banner"
+				},
+				"video": {
+					"$ref": "#/definitions/video"
+				},
+				"audio": {
+					"$ref": "#/definitions/audio"
+				},
+				"native": {
+					"$ref": "#/definitions/native"
+				},
+				"displaymanager": {
+					"type": "string"
+				},
+				"displaymanagerver": {
+					"type": "string"
+				},
+				"instl": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"tagid": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"clickbrowser": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"secure": {
+				   "$ref": "#/definitions/boolean_int"
+				},
+				"iframebuster": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"pmp": {
+					"$ref": "#/definitions/pmp"
+				},
+				"exp": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"banner": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"format": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/format"
+					}
+				},
+				"wmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmax": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"wmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"hmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"id": {
+					"type": "string"
+				},
+				"btype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner_ad_type"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"topframe": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"expdir": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/expandable_direction"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"video": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"
+					}
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"linearity": {
+					"$ref": "#/definitions/video_linearity"
+				},
+				"skip": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"skipmin": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"skipafter": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"boxingallowed": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"playbackmethod": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_playback_method"
+					}
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"pos": {
+					"$ref": "#/definitions/ad_position"
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/vast_companion_type"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"audio": {
+			"type": "object",
+			"required": [ "mimes" ],
+			"additionalProperties": false,
+			"properties": {
+				"mimes": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"minduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxduration": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"protocols": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/video_bid_response_protocol"	
+					}
+				},
+				"startdelay": {
+					"$ref": "#/definitions/video_start_delay"
+				},
+				"sequence": {
+					"type": "integer"
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#definitions/creative_attribute"
+					}
+				},
+				"maxextended": {
+					"type": "integer",
+					"minimum": -1
+				},
+				"minbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"maxbitrate": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"delivery": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_delivery_method"
+					}
+				},
+				"companionad": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/banner"
+					}
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"companiontype": {
+					"type": "array",
+					"items": {
+						"$ref": "#definitions/vast_companion_type"
+					}
+				},
+				"maxseq": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"feed": {
+					"$ref": "#/definitions/audio_feed_type"
+				},
+				"stitched": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"nvol": {
+					"$ref": "#/definitions/volume_normalization_mode"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"native": {
+			"type": "object",
+			"required": [ "request" ],
+			"additionalProperties": false,
+			"properties": {
+				"request": {
+					"type": "string"
+				},
+				"ver": {
+					"type": "string"
+				},
+				"api": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/api_framework"
+					}
+				},
+				"battr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"format": {
+			"type": "object",
+			"description": "represents an allowed size for a banner impression",
+			"additionalProperties": false,
+			"properties": {
+				"w": {
+						"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+						"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"site": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"page": {
+					"type": "string"
+				},
+				"ref": {
+					"type": "string"
+				},
+				"search": {
+					"type": "string"
+				},
+				"mobile": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"app": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"storeurl": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"sectioncat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"pagecat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"ver": {
+					"type": "string"
+				},
+				"privacypolicy": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"paid": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"publisher": {
+					"$ref": "#/definitions/publisher"
+				},
+				"content": {
+					"$ref": "#/definitions/content"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"publisher": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/factual_content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"content": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"episode": {
+					"type": "integer"
+				},
+				"title": {
+					"type": "string"
+				},
+				"series": {
+					"type": "string"
+				},
+				"season": {
+					"type": "string"
+				},
+				"artist": {
+					"type": "string"
+				},
+				"genre": {
+					"type": "string"
+				},
+				"album": {
+					"type": "string"
+				},
+				"isrc": {
+					"type": "string"
+				},
+				"producer": {
+					"$ref": "#/definitions/producer"
+				},
+				"url": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"prodq": {
+					"$ref": "#/definitions/production_quality"
+				},
+				"videoquality": {
+					"$ref": "#/definitions/production_quality"
+				},
+				"context": {
+					"$ref": "#/definitions/content_context"
+				},
+				"contentrating": {
+					"type": "string"
+				},
+				"userrating": {
+					"type": "string"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"livestream": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"sourcerelationship": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"len": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"embeddable": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"producer": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"domain": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"device": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"ua": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"dnt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"lmt": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ip": {
+					"type": "string",
+					"format": "ipv4"
+				},
+				"ipv6": {
+					"type": "string",
+					"format": "ipv6"
+				},
+				"devicetype": {
+					"$ref": "#/definitions/device_type"
+				},
+				"make": {
+					"type": "string"
+				},
+				"model": {
+					"type": "string"
+				},
+				"os": {
+					"type": "string"
+				},
+				"osv": {
+					"type": "string"
+				},
+				"hwv": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ppi": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"pxratio": {
+					"type": "number"
+				},
+				"js": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"geofetch": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"flashver": {
+					"type": "string"
+				},
+				"language": {
+					"$ref": "#/definitions/language"
+				},
+				"carrier": {
+					"type": "string"
+				},
+				"connectiontype": {
+					"$ref": "#/definitions/connection_type"
+				},
+				"ifa": {
+					"type": "string"
+				},
+				"didsha1": {
+					"type": "string"
+				},
+				"didmd5": {
+					"type": "string"
+				},
+				"dpidsha1": {
+					"type": "string"
+				},
+				"dpidmd5": {
+					"type": "string"
+				},
+				"macsha1": {
+					"type": "string"
+				},
+				"macmd5": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"geo": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"lat": {
+					"type": "number",
+					"minimum": -90,
+					"maximum": 90
+				},
+				"lon": {
+					"type": "number",
+					"minimum": -180,
+					"maximum": 180
+				},
+				"type": {
+					"$ref": "#/definitions/location_type"
+				},
+				"accuracy": {
+					"type": "integer"
+				},
+				"lastfix": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ipservice": {
+					"$ref": "#/definitions/ip_location_services"
+				},
+				"country": {
+					"type": "string",
+					"minLength": 3,
+					"maxLength": 3
+				},
+				"region": {
+					"type": "string"
+				},
+				"regionfips104": {
+					"type": "string"
+				},
+				"metro": {
+					"type": "string"
+				},
+				"city": {
+					"type": "string"
+				},
+				"zip": {
+					"type": "string"
+				},
+				"utcoffset": {
+					"type": "integer"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"user": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"buyeruid": {
+					"type": "string"
+				},
+				"yob": {
+					"type": "integer",
+					"minimum": 1000,
+					"maximum": 9999
+				},
+				"gender": {
+					"type": "string",
+					"enum": [
+						"M", "F", "O"
+					]
+				},
+				"keywords": {
+					"type": "string"
+				},
+				"customdata": {
+					"type": "string"
+				},
+				"geo": {
+					"$ref": "#/definitions/geo"
+				},
+				"data": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/data"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}			
+		},
+		"data": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"segment": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/segment"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"segment": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "string"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"regs": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"coppa": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"pmp": {
+			"type": "object",
+			"additionalProperties": false,
+			"properties": {
+				"private_auction": {
+					"$ref": "#/definitions/boolean_int",
+					"default": 0
+				},
+				"deals": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/deal"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"deal": {
+			"type": "object",
+			"required": [ "id" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"bidfloor": {
+					"type": "number",
+					"minimum": 0
+				},
+				"bidfloorcur": {
+				   "$ref": "#/definitions/currency"
+				},
+				"at": {
+					"type": "integer"
+				},
+				"wseat": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"wadomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		
+		
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		
+		"factual_content_category": {
+			"type": "string",
+			"enum": [
+				"1","2","3","4","5","6","7","8","9","10",
+				"11","12","13","14","15","16","17","18","19","20",
+				"21","22","23","24","25","26","27","28","29","30",
+				"31","32","33","34","35","36","37","38","39","40",
+				"41","42","43","44","45","46","47","48","49","50",
+				"51","52","53","54","55","56","57","58","59","60",
+				"61","62","63","64","65","66","67","68","69","70",
+				"71","72","73","74","75","76","77","78","79","80",
+				"81","82","83","84","85","86","87","88","89","90",
+				"91","92","93","94","95","96","97","98","99","100",
+				"101","102","103","104","105","106","107","108","109","110",
+				"111","112","113","114","115","116","117","118","119","120",
+				"121","122","123","124","125","126","127","128","129","130",
+				"131","132","133","134","135","136","137","138","139","140",
+				"141","142","143","144","145","146","147","148","149","150",
+				"151","152","153","154","155","156","157","158","159","160",
+				"161","162","163","164","165","166","167","168","169","170",
+				"171","172","173","174","175","176","177","178","179","180",
+				"181","182","183","184","185","186","187","188","189","190",
+				"191","192","193","194","195","196","197","198","199","200",
+				"201","202","203","204","205","206","207","208","209","210",
+				"211","212","213","214","215","216","217","218","219","220",
+				"221","222","223","224","225","226","227","228","229","230",
+				"231","232","233","234","235","236","237","238","239","240",
+				"241","242","243","244","245","246","247","248","249","250",
+				"251","252","253","254","255","256","257","258","259","260",
+				"261","262","263","264","265","266","267","268","269","270",
+				"271","272","273","274","275","276","277","278","279","280",
+				"281","282","283","284","285","286","287","288","289","290",
+				"291","292","293","294","295","296","297","298","299","300",
+				"301","302","303","304","305","306","307","308","309","310",
+				"311","312","313","314","315","316","317","318","319","320",
+				"321","322","323","324","325","326","327","328","329","330",
+				"331","332","333","334","335","336","337","338","339","340",
+				"341","342","343","344","345","346","347","348","349","350",
+				"351","352","353","354","355","356","357","358","359","360",
+				"361","362","363","364","365","366","367","368","369","370",
+				"371","372","373","374","375","376","377","378","379","380",
+				"381","382","383","384","385","386","387","388","389","390",
+				"391","392","393","394","395","396","397","398","399","400",
+				"401","402","403","404","405","406","407","408","409","410",
+				"411","412","413","414","415","416","417","418","419","420",
+				"421","422","423","424","425","426","427","428","429","430",
+				"431","432","433","434","435","436","437","438","439","440",
+				"441","442","443","444","445","446","447","448","449","450",
+				"451","452","453","454","455","456","457","458","459","460",
+				"461","462","463","464","465","466"
+			]
+		},
+		"banner_ad_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 17
+		},
+		"ad_position": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 7
+		},
+		"expandable_direction": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},		
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"video_linearity": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 2
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 10
+		},
+		"video_playback_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"video_start_delay": {
+			"type": "integer",
+			"minimum": -2
+		},
+		"production_quality": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+		"vast_companion_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_delivery_method": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"content_context": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"location_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"device_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 7
+		},		
+		"connection_type": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 6
+		},
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		},
+		"language": {
+			"type": "string",
+			"minLength": 2,
+			"maxLength": 2
+		},
+		"audio_feed_type": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"ip_location_services": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 4
+		},
+		"volume_normalization_mode": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 4
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-response_v1-0.json
+++ b/schemas/openrtb-schema_bid-response_v1-0.json
@@ -1,0 +1,128 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v1_0-schema-bid_response",
+	"description": "json schema for an openrtb v1.0 bid response (http://openrtb.googlecode.com/files/OpenRTB%20Mobile%20RTB%20API%20-%201.0.pdf)",
+	"type": "object",
+	"required": [ "id" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "$ref": "#/definitions/string_40"
+		},
+		"bidid": {
+		    "$ref": "#/definitions/string_40"
+		},
+		"nbr": {
+		    "$ref": "#/definitions/no_bid_reason"
+		},
+		"cur": {
+		    "$ref": "#/definitions/currency"
+		},
+		"units": {
+		    "$ref": "#/definitions/price_units"
+		},
+		"seatbid": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		}
+	},
+    "definitions": {
+		"seatbid": {
+			"type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"seat": {
+				    "$ref": "#/definitions/string_40"
+				},
+				"group": {
+				    "$ref": "#/definitions/boolean_int"
+				},
+				"bid": {
+		            "type": "array",
+				    "items": {
+						"$ref": "#/definitions/bid"
+					}
+				}
+			}
+		},
+		"bid": {
+	        "type": "object",
+			"required": [ "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"impid": {
+				    "$ref": "#/definitions/string_40"
+				},
+				"price": {
+					"type": "number",
+					"minimum": 0
+				},
+				"adid": {
+				    "$ref": "#/definitions/string_40"
+				},
+				"nurl": {
+				    "type": "string",
+				    "maxLength": 256
+				},
+				"adm": {
+				    "type": "string",
+				    "maxLength": 1024
+				},
+				"adomain": {
+				    "type": "string"
+				},
+				"iurl": {
+				    "type": "string"
+				},
+				"cid": {
+				    "type": "string"
+				},
+				"crid": {
+				    "type": "string"
+				},
+				"attr": {
+		            "type": "array",
+				    "items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				}
+			}
+		},
+
+
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 14
+		},
+		"price_units": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 2
+		},
+		"no_bid_reason": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 3
+		},
+
+
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 4
+		},
+		"string_40": {
+		    "type": "string",
+		    "maxLength": 40
+		}
+	}
+}

--- a/schemas/openrtb-schema_bid-response_v2-0.json
+++ b/schemas/openrtb-schema_bid-response_v2-0.json
@@ -1,0 +1,122 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_0-schema-bid_response",
+	"description": "json schema for an openrtb v2.0 bid response (http://www.iab.net/media/file/OpenRTB_API_Specification_Version2.0_FINAL.PDF)",
+	"type": "object",
+	"required": [ "id", "seatbid" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "type": "string"
+		},
+		"seatbid": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		},
+		"bidid": {
+			"type": "string"
+		},
+		"cur": {
+			"$ref": "#/definitions/currency"
+		},
+		"customdata": {
+			"type": "string"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+    "definitions": {
+		"seatbid": {
+	        "type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"bid": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bid"
+					}
+				},
+				"seat": {
+					"type": "string"
+				},
+				"group": {
+					"$ref": "#/definitions/boolean_int"
+				}
+			}
+		},
+		"bid": {
+	        "type": "object",
+			"required": [ "id", "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+				    "type": "string"
+				},
+				"impid": {
+				    "type": "string"
+				},
+				"price": {
+				    "type": "number",
+				    "minimum": 0
+				},
+				"adid": {
+				    "type": "string"
+				},
+				"nurl": {
+				    "type": "string"
+				},
+				"adm": {
+				    "type": "string"
+				},
+				"adomain": {
+					"type": "array",
+					"items": {
+					    "type": "string"
+					}
+				},
+				"iurl": {
+				    "type": "string"
+				},
+				"cid": {
+				    "type": "string"
+				},
+				"crid": {
+				    "type": "string"
+				},
+				"attr": {
+					"type": "array",
+					"items": {
+					    "$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+				    "type": "object"
+				}
+			}
+		},
+
+
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 3,
+		    "pattern": "[a-zA-Z]{3}"
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-response_v2-1.json
+++ b/schemas/openrtb-schema_bid-response_v2-1.json
@@ -1,0 +1,125 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_1-schema-bid_response",
+	"description": "json schema for an openrtb v2.1 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-1-FINAL.pdf)",
+	"type": "object",
+	"required": [ "id", "seatbid" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+		    "type": "string"
+		},
+		"seatbid": {
+            "type": "array",
+		    "items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		},
+		"bidid": {
+			"type": "string"
+		},
+		"cur": {
+			"$ref": "#/definitions/currency"
+		},
+		"customdata": {
+			"type": "string"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+    "definitions": {
+		"seatbid": {
+	        "type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"bid": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bid"
+					}
+				},
+				"seat": {
+					"type": "string"
+				},
+				"group": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"bid": {
+	        "type": "object",
+			"required": [ "id", "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+				    "type": "string"
+				},
+				"impid": {
+				    "type": "string"
+				},
+				"price": {
+				    "type": "number",
+				    "minimum": 0
+				},
+				"adid": {
+				    "type": "string"
+				},
+				"nurl": {
+				    "type": "string"
+				},
+				"adm": {
+				    "type": "string"
+				},
+				"adomain": {
+					"type": "array",
+					"items": {
+					    "type": "string"
+					}
+				},
+				"iurl": {
+				    "type": "string"
+				},
+				"cid": {
+				    "type": "string"
+				},
+				"crid": {
+				    "type": "string"
+				},
+				"attr": {
+					"type": "array",
+					"items": {
+					    "$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"ext": {
+				    "type": "object"
+				}
+			}
+		},
+
+
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"currency": {
+		    "type": "string",
+		    "minLength": 3,
+		    "maxLength": 3,
+		    "pattern": "[a-zA-Z]{3}"
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-response_v2-2.json
+++ b/schemas/openrtb-schema_bid-response_v2-2.json
@@ -1,0 +1,146 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_2-schema-bid_response",
+	"description": "json schema for an openrtb v2.2 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-1-FINAL.pdf)",
+	"type": "object",
+	"required": [ "id", "seatbid" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"seatbid": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		},
+		"bidid": {
+			"type": "string"
+		},
+		"cur": {
+			"$ref": "#/definitions/currency"
+		},
+		"customdata": {
+			"type": "string"
+		},
+		"nbr": {
+			"$ref": "#/definitions/nobid_reason"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"seatbid": {
+			"type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"bid": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bid"
+					}
+				},
+				"seat": {
+					"type": "string"
+				},
+				"group": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"bid": {
+			"type": "object",
+			"required": [ "id", "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"impid": {
+					"type": "string"
+				},
+				"price": {
+					"type": "number",
+					"minimum": 0
+				},
+				"adid": {
+					"type": "string"
+				},
+				"nurl": {
+					"type": "string"
+				},
+				"adm": {
+					"type": "string"
+				},
+				"adomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"iurl": {
+					"type": "string"
+				},
+				"cid": {
+					"type": "string"
+				},
+				"crid": {
+					"type": "string"
+				},
+				"attr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"dealid": {
+					"type": "string"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+
+
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"nobid_reason_code": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 8
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-response_v2-3.json
+++ b/schemas/openrtb-schema_bid-response_v2-3.json
@@ -1,0 +1,186 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_3-schema-bid_response",
+	"description": "json schema for an openrtb v2.3 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-3.pdf)",
+	"type": "object",
+	"required": [ "id", "seatbid" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"seatbid": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		},
+		"bidid": {
+			"type": "string"
+		},
+		"cur": {
+			"$ref": "#/definitions/currency"
+		},
+		"customdata": {
+			"type": "string"
+		},
+		"nbr": {
+			"$ref": "#/definitions/nobid_reason"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"seatbid": {
+			"type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"bid": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bid"
+					}
+				},
+				"seat": {
+					"type": "string"
+				},
+				"group": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"bid": {
+			"type": "object",
+			"required": [ "id", "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"impid": {
+					"type": "string"
+				},
+				"price": {
+					"type": "number",
+					"minimum": 0
+				},
+				"adid": {
+					"type": "string"
+				},
+				"nurl": {
+					"type": "string"
+				},
+				"adm": {
+					"type": "string"
+				},
+				"adomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"iurl": {
+					"type": "string"
+				},
+				"cid": {
+					"type": "string"
+				},
+				"crid": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"attr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"dealid": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+
+
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 16
+		},
+		"nobid_reason_code": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 8
+		},
+
+		
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		}
+	}	
+}

--- a/schemas/openrtb-schema_bid-response_v2-4.json
+++ b/schemas/openrtb-schema_bid-response_v2-4.json
@@ -1,0 +1,211 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "openrtb-v2_4-schema-bid_response",
+	"description": "json schema for an openrtb v2.4 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-4.pdf)",
+	"type": "object",
+	"required": [ "id", "seatbid" ],
+	"additionalProperties": false,
+	"properties": {
+		"id": {
+			"type": "string"
+		},
+		"seatbid": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/seatbid"
+			}
+		},
+		"bidid": {
+			"type": "string"
+		},
+		"cur": {
+			"$ref": "#/definitions/currency"
+		},
+		"customdata": {
+			"type": "string"
+		},
+		"nbr": {
+			"$ref": "#/definitions/nobid_reason"
+		},
+		"ext": {
+			"type": "object"
+		}
+	},
+	"definitions": {
+		"seatbid": {
+			"type": "object",
+			"required": [ "bid" ],
+			"additionalProperties": false,
+			"properties": {
+				"bid": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/bid"
+					}
+				},
+				"seat": {
+					"type": "string"
+				},
+				"group": {
+					"$ref": "#/definitions/boolean_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+		"bid": {
+			"type": "object",
+			"required": [ "id", "impid", "price" ],
+			"additionalProperties": false,
+			"properties": {
+				"id": {
+					"type": "string"
+				},
+				"impid": {
+					"type": "string"
+				},
+				"price": {
+					"type": "number",
+					"minimum": 0
+				},
+				"adid": {
+					"type": "string"
+				},
+				"nurl": {
+					"type": "string"
+				},
+				"adm": {
+					"type": "string"
+				},
+				"adomain": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				},
+				"bundle": {
+					"type": "string"
+				},
+				"iurl": {
+					"type": "string"
+				},
+				"cid": {
+					"type": "string"
+				},
+				"crid": {
+					"type": "string"
+				},
+				"cat": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/content_category"
+					}
+				},
+				"attr": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/creative_attribute"
+					}
+				},
+				"api": {
+					"$ref": "#/definitions/api_framework"
+				},
+				"protocol": {
+					"$ref": "#/definitions/video_bid_response_protocol"
+				},
+				"qagmediarating": {
+					"$ref": "#/definitions/qag_media_rating"
+				},
+				"exp": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"dealid": {
+					"type": "string"
+				},
+				"h": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"w": {
+					"$ref": "#/definitions/positive_int"
+				},
+				"ext": {
+					"type": "object"
+				}
+			}
+		},
+
+
+		"content_category": {
+			"type": "string",
+			"enum": [
+				"IAB1", "IAB1-1", "IAB1-2", "IAB1-3", "IAB1-4", "IAB1-5", "IAB1-6", "IAB1-7",
+				"IAB2", "IAB2-1", "IAB2-2", "IAB2-3", "IAB2-4", "IAB2-5", "IAB2-6", "IAB2-7", "IAB2-8", "IAB2-9", "IAB2-10", "IAB2-11", "IAB2-12", "IAB2-13", "IAB2-14", "IAB2-15", "IAB2-16", "IAB2-17", "IAB2-18", "IAB2-19", "IAB2-20", "IAB2-21", "IAB2-22", "IAB2-23",
+				"IAB3", "IAB3-1", "IAB3-2", "IAB3-3", "IAB3-4", "IAB3-5", "IAB3-6", "IAB3-7", "IAB3-8", "IAB3-9", "IAB3-10", "IAB3-11", "IAB3-12",
+				"IAB4", "IAB4-1", "IAB4-2", "IAB4-3", "IAB4-4", "IAB4-5", "IAB4-6", "IAB4-7", "IAB4-8", "IAB4-9", "IAB4-10", "IAB4-11",
+				"IAB5", "IAB5-1", "IAB5-2", "IAB5-3", "IAB5-4", "IAB5-5", "IAB5-6", "IAB5-7", "IAB5-8", "IAB5-9", "IAB5-10", "IAB5-11", "IAB5-12", "IAB5-13", "IAB5-14", "IAB5-15",
+				"IAB6", "IAB6-1", "IAB6-2", "IAB6-3", "IAB6-4", "IAB6-5", "IAB6-6", "IAB6-7", "IAB6-8", "IAB6-9",
+				"IAB7", "IAB7-1", "IAB7-2", "IAB7-3", "IAB7-4", "IAB7-5", "IAB7-6", "IAB7-7", "IAB7-8", "IAB7-9", "IAB7-10", "IAB7-11", "IAB7-12", "IAB7-13", "IAB7-14", "IAB7-15", "IAB7-16", "IAB7-17", "IAB7-18", "IAB7-19", "IAB7-20", "IAB7-21", "IAB7-22", "IAB7-23", "IAB7-24", "IAB7-25", "IAB7-26", "IAB7-27", "IAB7-28", "IAB7-29", "IAB7-30", "IAB7-31", "IAB7-32", "IAB7-33", "IAB7-34", "IAB7-35", "IAB7-36", "IAB7-37", "IAB7-38", "IAB7-39", "IAB7-40", "IAB7-41", "IAB7-42", "IAB7-43", "IAB7-44", "IAB7-45",
+				"IAB8", "IAB8-1", "IAB8-2", "IAB8-3", "IAB8-4", "IAB8-5", "IAB8-6", "IAB8-7", "IAB8-8", "IAB8-9", "IAB8-10", "IAB8-11", "IAB8-12", "IAB8-13", "IAB8-14", "IAB8-15", "IAB8-16", "IAB8-17", "IAB8-18",
+				"IAB9", "IAB9-1", "IAB9-2", "IAB9-3", "IAB9-4", "IAB9-5", "IAB9-6", "IAB9-7", "IAB9-8", "IAB9-9", "IAB9-10", "IAB9-11", "IAB9-12", "IAB9-13", "IAB9-14", "IAB9-15", "IAB9-16", "IAB9-17", "IAB9-18", "IAB9-19", "IAB9-20", "IAB9-21", "IAB9-22", "IAB9-23", "IAB9-24", "IAB9-25", "IAB9-26", "IAB9-27", "IAB9-28", "IAB9-29", "IAB9-30", "IAB9-31",
+				"IAB10", "IAB10-1", "IAB10-2", "IAB10-3", "IAB10-4", "IAB10-5", "IAB10-6", "IAB10-7", "IAB10-8", "IAB10-9",
+				"IAB11", "IAB11-1", "IAB11-2", "IAB11-3", "IAB11-4", "IAB11-5",
+				"IAB12", "IAB12-1", "IAB12-2", "IAB12-3",
+				"IAB13", "IAB13-1", "IAB13-2", "IAB13-3", "IAB13-4", "IAB13-5", "IAB13-6", "IAB13-7", "IAB13-8", "IAB13-9", "IAB13-10", "IAB13-11", "IAB13-12",
+				"IAB14", "IAB14-1", "IAB14-2", "IAB14-3", "IAB14-4", "IAB14-5", "IAB14-6", "IAB14-7", "IAB14-8",
+				"IAB15", "IAB15-1", "IAB15-2", "IAB15-3", "IAB15-4", "IAB15-5", "IAB15-6", "IAB15-7", "IAB15-8", "IAB15-9", "IAB15-10",
+				"IAB16", "IAB16-1", "IAB16-2", "IAB16-3", "IAB16-4", "IAB16-5", "IAB16-6", "IAB16-7",
+				"IAB17", "IAB17-1", "IAB17-2", "IAB17-3", "IAB17-4", "IAB17-5", "IAB17-6", "IAB17-7", "IAB17-8", "IAB17-9", "IAB17-10", "IAB17-11", "IAB17-12", "IAB17-13", "IAB17-14", "IAB17-15", "IAB17-16", "IAB17-17", "IAB17-18", "IAB17-19", "IAB17-20", "IAB17-21", "IAB17-22", "IAB17-23", "IAB17-24", "IAB17-25", "IAB17-26", "IAB17-27", "IAB17-28", "IAB17-29", "IAB17-30", "IAB17-31", "IAB17-32", "IAB17-33", "IAB17-34", "IAB17-35", "IAB17-36", "IAB17-37", "IAB17-38", "IAB17-39", "IAB17-40", "IAB17-41", "IAB17-42", "IAB17-43", "IAB17-44",
+				"IAB18", "IAB18-1", "IAB18-2", "IAB18-3", "IAB18-4", "IAB18-5", "IAB18-6",
+				"IAB19", "IAB19-1", "IAB19-2", "IAB19-3", "IAB19-4", "IAB19-5", "IAB19-6", "IAB19-7", "IAB19-8", "IAB19-9", "IAB19-10", "IAB19-11", "IAB19-12", "IAB19-13", "IAB19-14", "IAB19-15", "IAB19-16", "IAB19-17", "IAB19-18", "IAB19-19", "IAB19-20", "IAB19-21", "IAB19-22", "IAB19-23", "IAB19-24", "IAB19-25", "IAB19-26", "IAB19-27", "IAB19-28", "IAB19-29", "IAB19-30", "IAB19-31", "IAB19-32", "IAB19-33", "IAB19-34", "IAB19-35", "IAB19-36",
+				"IAB20", "IAB20-1", "IAB20-2", "IAB20-3", "IAB20-4", "IAB20-5", "IAB20-6", "IAB20-7", "IAB20-8", "IAB20-9", "IAB20-10", "IAB20-11", "IAB20-12", "IAB20-13", "IAB20-14", "IAB20-15", "IAB20-16", "IAB20-17", "IAB20-18", "IAB20-19", "IAB20-20", "IAB20-21", "IAB20-22", "IAB20-23", "IAB20-24", "IAB20-25", "IAB20-26", "IAB20-27",
+				"IAB21", "IAB21-1", "IAB21-2", "IAB21-3",
+				"IAB22", "IAB22-1", "IAB22-2", "IAB22-3", "IAB22-4",
+				"IAB23", "IAB23-1", "IAB23-2", "IAB23-3", "IAB23-4", "IAB23-5", "IAB23-6", "IAB23-7", "IAB23-8", "IAB23-9", "IAB23-10",
+				"IAB24",
+				"IAB25", "IAB25-1", "IAB25-2", "IAB25-3", "IAB25-4", "IAB25-5", "IAB25-6", "IAB25-7",
+				"IAB26", "IAB26-1", "IAB26-2", "IAB26-3", "IAB26-4"
+			]
+		},
+		"creative_attribute": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 17
+		},
+		"nobid_reason_code": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 8
+		},
+		"boolean_int": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 1
+		},
+		"positive_int": {
+			"type": "integer",
+			"minimum": 0
+		},
+		"api_framework": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 5
+		},
+		"video_bid_response_protocol": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 10
+		},
+		"qag_media_rating": {
+			"type": "integer",
+			"minimum": 1,
+			"maximum": 3
+		},
+		"currency": {
+			"type": "string",
+			"minLength": 3,
+			"maxLength": 3,
+			"pattern": "[a-zA-Z]{3}"
+		}
+	}	
+}


### PR DESCRIPTION
From https://github.com/ad-tech-group/openssp/tree/master/open-ssp-parent/open-ssp-openrtb-validator/src/main/resources/schemas

To ease bid request and response validation, it's really useful to have the associated JSON schemas. @amitshetty suggests me to create a PR directly into this repository to store them. 