### PR TITLE
Add Audigent Taxonomy ID Range

### DIFF
--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -1,6 +1,6 @@
 # Segment Taxonomies
 
-Sponsors: CafeMedia, Magnite (formerly Rubicon Project), PubMatic
+Sponsors: CafeMedia, Magnite (formerly Rubicon Project), PubMatic, Audigent
 
 ## Overview
 

--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -253,7 +253,7 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
         <strong>103012</strong>
       </td>
       <td>
-        Audigent Test Taxonomy 1
+        Audigent Campaign Taxonomy 1
       </td>
     </tr>
   <tr>
@@ -261,7 +261,7 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
         <strong>103013</strong>
       </td>
       <td>
-        Audigent Test Taxonomy 2
+        Audigent Campaign Taxonomy 2
       </td>
     </tr>
   <tr>
@@ -269,7 +269,7 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
         <strong>103014</strong>
       </td>
       <td>
-        Audigent Test Taxonomy 3
+        Audigent Campaign Taxonomy 3
       </td>
     </tr>
   </tbody>

--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -152,5 +152,125 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
         Iris video taxonomy. More info - <a href="https://blog.iris.tv/video-programming-playbook-metadata-taxonomy">https://blog.iris.tv/video-programming-playbook-metadata-taxonomy</a>
       </td>
     </tr>
+  <tr>
+      <td>
+        <strong>103000</strong>
+      </td>
+      <td>
+        Audigent Warner Music Group Artists Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103001</strong>
+      </td>
+      <td>
+        Audigent Bands in Town Artists Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103002</strong>
+      </td>
+      <td>
+        Audigent Fandom Interests & Audiences Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103003</strong>
+      </td>
+      <td>
+        Audigent Big Machine Label Group Artists Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103004</strong>
+      </td>
+      <td>
+        Audigent Music Festival Partner Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103005</strong>
+      </td>
+      <td>
+        Audigent Fashion & Apparel Taxonomy 1.0
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103006</strong>
+      </td>
+      <td>
+        Audigent Private Audience Taxonomy 1
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103007</strong>
+      </td>
+      <td>
+        Audigent Private Audience Taxonomy 2
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103008</strong>
+      </td>
+      <td>
+        Audigent Private Audience Taxonomy 3
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103009</strong>
+      </td>
+      <td>
+        Audigent Private Contextual Taxonomy 1
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103010</strong>
+      </td>
+      <td>
+        Audigent Private Contextual Taxonomy 2
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103011</strong>
+      </td>
+      <td>
+        Audigent Private Contextual Taxonomy 3
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103012</strong>
+      </td>
+      <td>
+        Audigent Test Taxonomy 1
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103013</strong>
+      </td>
+      <td>
+        Audigent Test Taxonomy 2
+      </td>
+    </tr>
+  <tr>
+      <td>
+        <strong>103014</strong>
+      </td>
+      <td>
+        Audigent Test Taxonomy 3
+      </td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
This PR is a request for a a taxonomy ID range to be assigned to Audigent in the segtax community extension list.  The format reflects where we arrived at  in https://github.com/prebid/Prebid.js/issues/6057 along with the various discussions both in the OpenRTB 2.6 and Prebid Taxonomy meetings.  We will be working with supply and demand platforms to distribute definitions for and enable these taxonomies in the coming weeks.