### PR TITLE
Register Optable audience segtax IDs

### DIFF
--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -154,6 +154,18 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
       	<td>502</td><td>JW Player video content taxonomy</td>
       </tr>
   <tr>
+    <td>5000</td>
+    <td>Optable Data Collaboration Platform - Public Audiences</td>
+  </tr>
+  <tr>
+    <td>5001</td>
+    <td>Optable Data Collaboration Platform - Private Member Defined Audiences</td>
+  </tr>
+  <tr>
+    <td>5002</td>
+    <td>Optable Data Collaboration Platform - Test Audiences</td>
+  </tr>
+  <tr>
       <td>103000</td>
       <td>
         Audigent Warner Music Group Artists Taxonomy 1.0


### PR DESCRIPTION
Request registration of segtax IDs for Optable Data Collaboration Platform:

- 5000: Public Audiences
- 5001: Private Member Defined Audiences
- 5002: Test Audiences
