### PR TITLE
Propose a GPC extension to OpenRTB

### DIFF
--- a/extensions/community_extensions/GPC.md
+++ b/extensions/community_extensions/GPC.md
@@ -18,7 +18,7 @@ Request Changes
   <th>Description</th>
  </tr>
  <tr>
-  <td>content.ext.gpc</td>
+  <td>regs.ext.gpc</td>
   <td>integer</td>
   <td>1</td>
   <td>This value should exactly replicate the value in the Global Privacy Control signal setting that will be available at both the header and window level. Where GPC is set to 1 this should be set to 1 and where it is not present this property should not be present.</td>

--- a/extensions/community_extensions/GPC.md
+++ b/extensions/community_extensions/GPC.md
@@ -1,0 +1,38 @@
+### Global Privacy Control
+
+Issue: [#98](https://github.com/InteractiveAdvertisingBureau/openrtb/issues/98)
+
+The goal is to support passing the Global Privacy Control signal to downstream participants in order to allow them to make decisions on how to interpret the privacy state of a user in regard to applicable regulations. 
+
+Downstream consumers of this signal should use it as the primary signal where they believe it applies, since not all publishers may use the signal to change their interpretation of other privacy signals or may interpret it the same way as a downstream consumer. So, where the downstream consumer of OpenRTB signals sees both a USPAPI signal and a GPC signal on a request and considers the GPC signal to mean an opt-out in California, and where the USPAPI signal does not indicate such an opt-out, then the downstream consumer should consider the user opted-out.
+
+When the creator of the OpenRTB object sees a GPC signal they must set this extension with that signal.
+
+Request Changes
+
+<table>
+ <tr>
+  <th>Content Object</th>
+  <th>Type</th>
+  <th>Example values</th>
+  <th>Description</th>
+ </tr>
+ <tr>
+  <td>content.ext.gpc</td>
+  <td>integer</td>
+  <td>1</td>
+  <td>This value should exactly replicate the value in the Global Privacy Control signal setting that will be available at both the header and window level. Where GPC is set to 1 this should be set to 1 and where it is not present this property should not be present.</td>
+ </tr>
+</table>
+
+Example Request
+
+```
+{
+ "content":{
+  "ext":{
+   "gpc": 1
+  }
+ }
+}
+```

--- a/extensions/community_extensions/GPC.md
+++ b/extensions/community_extensions/GPC.md
@@ -29,7 +29,7 @@ Example Request
 
 ```
 {
- "content":{
+ "regs":{
   "ext":{
    "gpc": 1
   }

--- a/extensions/community_extensions/README.md
+++ b/extensions/community_extensions/README.md
@@ -17,7 +17,7 @@ See [digitrust.md](digitrust.md) for details.
 
 #### Notes
 
-See [ca-568.md](ca-568.md) for deatils.
+See [ca-568.md](ca-568.md) for details.
 
 ### URLs for Brand Safety
 
@@ -25,7 +25,7 @@ See [ca-568.md](ca-568.md) for deatils.
 
 #### Notes
 
-See [urls-brand-safety.md](urls-brand-safety.md) for deatils.
+See [urls-brand-safety.md](urls-brand-safety.md) for details.
 
 ### SKAdNetwork Support
 
@@ -33,7 +33,7 @@ See [urls-brand-safety.md](urls-brand-safety.md) for deatils.
 
 #### Notes
 
-See [skadnetwork.md](skadnetwork.md) for deatils.
+See [skadnetwork.md](skadnetwork.md) for details.
 
 ### SCID.id
 
@@ -41,7 +41,7 @@ See [skadnetwork.md](skadnetwork.md) for deatils.
 
 #### Notes
 
-See [SCID.md](SCID.md) for deatils.
+See [SCID.md](SCID.md) for details.
 
 ### Extended Content IDs
 
@@ -49,7 +49,7 @@ See [SCID.md](SCID.md) for deatils.
 
 #### Notes
 
-See [extended-content-ids.md](extended-content-ids.md) for deatils.
+See [extended-content-ids.md](extended-content-ids.md) for details.
 
 ### Global Privacy Control (GPC)
 
@@ -57,4 +57,4 @@ See [extended-content-ids.md](extended-content-ids.md) for deatils.
 
 #### Notes
 
-See [the Global Privacy Control website](https://globalprivacycontrol.org/) for deatils on the specification and its current market support.
+See [the Global Privacy Control website](https://globalprivacycontrol.org/) for details on the specification and its current market support.

--- a/extensions/community_extensions/README.md
+++ b/extensions/community_extensions/README.md
@@ -50,3 +50,11 @@ See [SCID.md](SCID.md) for deatils.
 #### Notes
 
 See [extended-content-ids.md](extended-content-ids.md) for deatils.
+
+### Global Privacy Control (GPC)
+
+#### Issue: [#98](https://github.com/InteractiveAdvertisingBureau/openrtb/issues/98)
+
+#### Notes
+
+See [the Global Privacy Control website](https://globalprivacycontrol.org/) for deatils on the specification and its current market support.


### PR DESCRIPTION
Intended to address #98

This is intended to apply to any applicable RTB version and I'd be happy to add to this PR if needed to allow it to apply to other iterations if maintainers will tell me what needs to be done in order to do so. I do not believe my organization is currently a Tech Lab member, however, if there are any questions I'd be glad to speak to the group. 

The goal is to support passing the Global Privacy Control signal to downstream participants in order to allow them to make decisions on how to interpret the privacy state of a user in regard to applicable regulations.

Downstream consumers of this signal should use it as the primary signal where they believe it applies, since not all publishers may use the signal to change their interpretation of other privacy signals or may interpret it the same way as a downstream consumer. So, where the downstream consumer of OpenRTB signals sees both a USPAPI signal and a GPC signal on a request and considers the GPC signal to mean an opt-out in California, and where the USPAPI signal does not indicate such an opt-out, then the downstream consumer should consider the user opted-out.

When the creator of the OpenRTB object sees a GPC signal they must set this extension with that signal.

