### PR TITLE
Wait, isn't segtax supposed to be a string?

### DIFF
--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -42,10 +42,10 @@ Per the OpenRTB 2.x API, the Data and Segment objects together allow additional 
         The ID for a taxonomy that is registered centrally, in a list maintained below.
       </td>
       <td>
-        integer
+        string
       </td>
       <td>
-        <code>3</code>
+        <code>"3"</code>
       </td>
     </tr>
   </tbody>

--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -63,7 +63,7 @@ The following example illustrates the usage of the new field in `BidRequest.user
       {
         "name": "a-data-provider.com",
         "ext": {
-          "segtax": 3
+          "segtax": "3"
         },
         "segment": [
           { "id": "1001" },


### PR DESCRIPTION
In this document, segtax is an integer, but according to the spec (https://iabtechlab.com/wp-content/uploads/2022/02/IAB-Tech-Lab-Taxonomy-and-Data-Transparency-Standards-to-Support-Seller-defined-Audience-and-Context-Signaling.pdf) it seems to be a string.

That being said, on page 17 of the spec it's also used as an integer.