### PR TITLE
Fix Seat Non-Bid JSON Example

### DIFF
--- a/extensions/community_extensions/seat-non-bid.md
+++ b/extensions/community_extensions/seat-non-bid.md
@@ -28,13 +28,13 @@ There are many reasons for a non bid scenario and it is understood not all can b
 {
     "id": "1234567890",
     "ext": {
-        "seatnonbid": {
+        "seatnonbid": [{
             "seat": "512",
-            "nonbid": {
+            "nonbid": [{
                 "impid": "102",
                 "statuscode": 301
-            }
-        }
+            }]
+        }]
     }
 }
 ```


### PR DESCRIPTION
Fields should be arrays, but are objects in the example.