### PR TITLE
Fix example of SKAdNetwork v4.0 signatures

### DIFF
--- a/extensions/community_extensions/skadnetwork.md
+++ b/extensions/community_extensions/skadnetwork.md
@@ -629,13 +629,13 @@ Fields that should have different values for the different fidelity types (e.g. 
               "fidelities": [
                 {
                   "fidelity": 0,
-                  "signature": "TUVRQ0lFUWxtWlJOZll6S0JTRThRbmhMVElIWlpaV0NGZ1pwUnFSeEhzczY1S29GQWlBSmdKS2pkcldka0xVT0NDanVFeDJS==",
+                  "signature": "MEQCIEQlmZRNfYzKBSE8QnhLTIHZZZWCFgZpRqRxHss65KoFAiAJgJKjdrWdkLUOCCjuEx2RmFS7daRzSVZRVZ8RyMyUXg==",
                   "nonce": "473b1a16-b4ef-43ad-9591-fcf3aefa82a7",
                   "timestamp": "1594406341"
                 },
                 {
                   "fidelity": 1,
-                  "signature": "VFVWUlEwbEZVV3h0V2xKT1psbDZTMEpUUlRoUmJtaE1WRWxJV2xwYVYwTkdaMXB3VW5GU2VFaHpjelkxUzI5R1FXbEJTbDBG==",
+                  "signature": "GRlMDktMmE5Zi00ZGMzLWE0ZDEtNTQ0YzQwMmU5MDk1IiwKICAgICAgICAgICAgICAgICAgInRpbWVzdGTk0NDA2MzQyIg==",
                   "nonce": "e650de09-2a9f-4dc3-a4d1-544c402e9095",
                   "timestamp": "1594406342"
                 }


### PR DESCRIPTION
## Background
[The generated binary signature is encoded in a Base64 string.](https://developer.apple.com/documentation/storekit/skadnetwork/generating_the_signature_to_validate_storekit-rendered_ads#2960813) but, the signature string in example (v4.0) is not a valid Base64 string.

## Changes
- The signature string in example (v4.0) changed to a valid Base64 string.

## Sample code
https://go.dev/play/p/oC3_Jmgf_O9
