### PR TITLE
Update deprecation_test_label.md (links to Google's new explainer &c.)

### DIFF
--- a/extensions/community_extensions/deprecation_test_label.md
+++ b/extensions/community_extensions/deprecation_test_label.md
@@ -3,7 +3,7 @@
 **Sponsor**: Epsilon
 
 **Background**:  
-Google recently published [an update](https://developer.chrome.com/docs/privacy-sandbox/chrome-testing/) regarding the UK CMA-aligned Chrome cookie deprecation testing labels announced in May. Chrome intends to label 9.5% percent of Chrome Stable browsers globally. A browser instance, if labeled, is either Mode A (8.5%, opt-in testing beginning Q4 2023) or Mode B (1%, forced cookie deprecation beginning Q1 2024). Two means are offered to access the label. One can read a request header after setting a special partitioned (CHIPS) cookie or client-side via a new `Navigator` script API promise. 
+Google recently published an update regarding the UK CMA-aligned Chrome cookie deprecation testing labels announced in May. Chrome intends to label 9.5% percent of Chrome Stable browsers globally. A browser instance, if labeled, is either Mode A (8.5%, opt-in testing beginning Q4 2023) or Mode B (1%, forced cookie deprecation beginning Q1 2024). Two means are offered to access the label. One can read a request header after setting a special partitioned (CHIPS) cookie or client-side via a new `Navigator` script API promise. 
 
 **Proposal**:  
 Entities are encouraged to access the label and to share the value unmodified with partners via the following `Device` extension.
@@ -25,42 +25,40 @@ Entities are encouraged to access the label and to share the value unmodified wi
 <br/><br/>  
   
 **Notes**  
-No requirement to communicate label provenance, header versus API access.
-
 Privacy Sandbox enrollment is _not_ required to access the labels.  
 
-If you have opinions or feedback about the test group labeling plans, the Chrome team has encouraged interested parties to weigh in on the Privacy Sandbox Developer Support “chrome-testing” issues. Link below. 
+If you have opinions or feedback about the test group labeling plans or deprecation in general, the Chrome team encourages interested parties to weigh in on the Privacy Sandbox Developer Support “chrome-testing” [issues](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/labels/chrome-testing).
 
 
 <br/>
 
 **References**  
-Chrome-facilitated testing (Chrome Developer Relations)  
+Cookie Deprecation Labeling Explainer (Google, GitHub, 25 Oct 2023)  
+[https://github.com/privacysandbox/tpcd-labeling/blob/main/cookie_deprecation_labeling_explainer.md](https://github.com/privacysandbox/tpcd-labeling/blob/main/cookie_deprecation_labeling_explainer.md)
+
+Intent to Experiment: Cookie Deprecation Labeling (Google, blink-dev, 25 Oct 2023)  
+[https://groups.google.com/a/chromium.org/g/blink-dev/c/3escBQGtIpM/m/ntcytva5BgAJ](https://groups.google.com/a/chromium.org/g/blink-dev/c/3escBQGtIpM/m/ntcytva5BgAJ)
+
+Cookie Deprecation Labeling (Chromes Feature Card, 25 Oct 2023)  
+[https://chromestatus.com/feature/5189079788683264](https://chromestatus.com/feature/5189079788683264)
+
+Chrome-facilitated testing (Chrome Developer Relations)   
 [https://developer.chrome.com/docs/privacy-sandbox/chrome-testing/](https://developer.chrome.com/docs/privacy-sandbox/chrome-testing/)
 
 Privacy Sandbox Developer Support “chrome-testing” issues, Github  
 [https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/labels/chrome-testing](https://github.com/GoogleChromeLabs/privacy-sandbox-dev-support/labels/chrome-testing)
 
-Chrome implementation Monorail issues  
-`Sec-Cookie-Deprecation` header access  
-[https://bugs.chromium.org/p/chromium/issues/detail?id=1479071](https://bugs.chromium.org/p/chromium/issues/detail?id=1479071)  
-Implement JS API for `navigator.cookieDeprecationLabel.getValue()`  
-[https://bugs.chromium.org/p/chromium/issues/detail?id=1479119](https://bugs.chromium.org/p/chromium/issues/detail?id=1479119)
-
-Chromium Dash Schedule (Chrome milestone releases)  
-[https://chromiumdash.appspot.com/schedule](https://chromiumdash.appspot.com/schedule)
-
 UK Competition and Markets Authority (CMA) Test Guidelines  
 [https://www.gov.uk/cma-cases/investigation-into-googles-privacy-sandbox-browser-changes#industry-testing](https://www.gov.uk/cma-cases/investigation-into-googles-privacy-sandbox-browser-changes#industry-testing)
 
-Privacy Sandbox enrollment and attestations model, GitHub  
-[https://github.com/privacysandbox/attestation/blob/main/README.md](https://github.com/privacysandbox/attestation/blob/main/README.md)
-
-PSA: Third-party cookie deprecation for 1% of Chrome Stable starting Q1 2024 (blink-dev)  
+PSA: Third-party cookie deprecation for 1% of Chrome Stable starting Q1 2024 (Google, blink-dev)
 [https://groups.google.com/a/chromium.org/g/blink-dev/c/GJl_aMO6Qt4/m/gFEMFo8FAgAJ](https://groups.google.com/a/chromium.org/g/blink-dev/c/GJl_aMO6Qt4/m/gFEMFo8FAgAJ)  
   
-Intent to Prototype: Third-Party Cookie Phaseout (blink-dev)  
+Intent to Prototype: Third-Party Cookie Phaseout (Google, blink-dev)  
 [https://groups.google.com/a/chromium.org/g/blink-dev/c/8mlWTOcEzcA/m/NZJSW0weAQAJ](https://groups.google.com/a/chromium.org/g/blink-dev/c/8mlWTOcEzcA/m/NZJSW0weAQAJ)
  
 Deprecate Third-Party Cookies (Chrome feature card)  
 [https://chromestatus.com/feature/5133113939722240](https://chromestatus.com/feature/5133113939722240)
+
+Privacy Sandbox enrollment and attestations model, GitHub  
+[https://github.com/privacysandbox/attestation/blob/main/README.md](https://github.com/privacysandbox/attestation/blob/main/README.md)


### PR DESCRIPTION
Links to Google's Intent to Experiment: Cookie Deprecation Labeling and new GH explainer posted today.