### PR TITLE
Proposed Seat NonBid code for responses rejected for privacy reasons

### DIFF
--- a/extensions/community_extensions/seat-non-bid.md
+++ b/extensions/community_extensions/seat-non-bid.md
@@ -316,6 +316,10 @@ There are many reasons for a non bid scenario and it is understood not all can b
       <td>Response Rejected - Below Deal Floor</td>
     </tr>
     <tr>
+      <td>305</td>
+      <td>Response Rejected - Privacy</td>
+    </tr>
+    <tr>
       <td>350</td>
       <td>Response Rejected - Invalid Creative</td>
     </tr>


### PR DESCRIPTION
This is being driven by DSA and validations that Prebid Server is making on the bid responses. e.g. if the request DSA field states "bid responses without DSA object will not be accepted", a reject reason would be helpful.

Mirroring the "Request Rejected - Privacy" that was added due to GDPR, this PR proposes "Response Rejected - Privacy" for the response side of the equation.