### PR TITLE
Addition of Name Spacing to PAA Ext

### DIFF
--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -39,7 +39,7 @@
 ## Object: InterestGroupAuctionIntent
 
 `BidResponse.ext.igi`: This extension to "Object: BidResponse" allows buyers and sellers to provide necessary signals in order to operate an Interest Group auction for a given ad slot. </br>
-Must include at least one buyer (`igb`, in the bid response from the buyer to the seller) or at least one seller (`igs`, from the seller to the publisher) object, but not both.
+Must include at least a buyer object (`igb`, in the bid response from the buyer to the seller) or seller object (`igs`, from the seller to the publisher) object, but not both.
 
 <table>
   <tr>

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -39,7 +39,7 @@
 ## Object: InterestGroupAuctionIntent
 
 `BidResponse.ext.igi`: This extension to "Object: BidResponse" allows buyers and sellers to provide necessary signals in order to operate an Interest Group auction for a given ad slot. </br>
-Must include at least a buyer object (`igb`, in the bid response from the buyer to the seller) or seller object (`igs`, from the seller to the publisher) object, but not both.
+Must include at least a buyer object (`igb`, in the bid response from the buyer to the seller) or seller object (`igs`, from the seller to the publisher), but not both.
 
 <table>
   <tr>

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -170,22 +170,28 @@ Component seller auction configuration should be submitted to the top-level sell
   </tr>
 </table>
 
-## Object: Request Namespace
+## List: Request Namespace
 <table>
   <tr>
-    <td><strong>Attribute</strong></td>
-    <td><strong>Type</strong></td>
+    <td><strong>Value</strong></td>
+    <td><strong>Definition</strong></td>
     <td><strong>Description</strong></td>
   </tr>
 <tr>
+    <td><code>1</code></td>
     <td><code>ortb2</code></td>
     <td>OpenRTB BidRequest</td>
-    <td>A sparse OpenRTB BidRequest. If an ORTB object is present in both auctionSignals and this location, the fields in perBuyerSignals take precedence.
-</td>
+    <td>A sparse OpenRTB BidRequest. If an ORTB object is present in both auctionSignals and this location, the fields in perBuyerSignals take precedence. </td>
   </tr>
 <tr>
-    <td><code>ext</code></td>
-    <td>string</td>
+    <td><code>2</code></td>
+    <td><code>Prebid</code></td>
+    <td>Prebid BidRequest</td>
+    <td>A sparse PreBid Bid Request. WHAT DO I PUT HERE</td>
+  </tr>
+<tr>
+    <td><code>500+</code></td>
+    <td>other</td>
     <td>Any programmatic bid request <b>not</b> structured as an OpenRTB request</td>
   </tr>
 </table>

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -151,6 +151,9 @@ Component seller auction configuration should be submitted to the top-level sell
   </tr>
 </table>
 
+# Non-OpenRTB Signaling
+If and only if the buyer opts into perBuyerSignals namespacing by returning pbsmap = 1 in <code>Object: InterestGroupAuctionBuyer</code>, then the seller provides perBuyerSignals in an structure object expected to be understood by implementers <i>a priori</i>. See Implementation Guidance (LINK) for additional detail.
+
 ## Object: InterestGroupAuctionBuyerSignals
 <table>
   <tr>
@@ -164,38 +167,12 @@ Component seller auction configuration should be submitted to the top-level sell
     <td>Value from the buyer, <code>OpenRTB BidResponse.ext.igi[].igb[].pbs.</code></td>
   </tr>
 <tr>
-    <td><code>requestnamespace</code></td>
+    <td><code>seller</code></td>
     <td>object</td>
-    <td>Namespace of the expected structure of the bid request. See Namespacing section in Implementation Guidance for additional details </td>
+    <td>If an ORTB object is present in both auctionSignals and this location, the fields in perBuyerSignals take precedence.
+</td>
   </tr>
 </table>
-
-## List: Request Namespace
-<table>
-  <tr>
-    <td><strong>Value</strong></td>
-    <td><strong>Definition</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-<tr>
-    <td><code>1</code></td>
-    <td><code>ortb2</code></td>
-    <td>OpenRTB BidRequest</td>
-    <td>A sparse OpenRTB BidRequest. If an ORTB object is present in both auctionSignals and this location, the fields in perBuyerSignals take precedence. </td>
-  </tr>
-<tr>
-    <td><code>2</code></td>
-    <td><code>Prebid</code></td>
-    <td>Prebid BidRequest</td>
-    <td>A sparse PreBid Bid Request. WHAT DO I PUT HERE</td>
-  </tr>
-<tr>
-    <td><code>500+</code></td>
-    <td>other</td>
-    <td>Any programmatic bid request <b>not</b> structured as an OpenRTB request</td>
-  </tr>
-</table>
-
 
 # Implementation Guidance
 
@@ -376,16 +353,18 @@ Following extends the Ad Served On Win Notice example to demonstrate a seller pl
 ```
 
 ### Namespacing
+Where participants in the auction are using the OpenRTB object model, the <code>seller</code> atrribute should <b>always</b> always have a sub-attribute called .ortb2.
+
 #### Namespacing in auctionSignals
 The auctionSignals metadata may originate from diverse sources, so this map should be ‘namespaced’ by the providing entity. Where an entity is using OpenRTB objects, it should provide them in an attribute named ortb2. For example:
 
-```json
+```jsonc
 {
    ...
    "auctionSignals": {
       "prebid": {
          "ortb2": {
-            "sparse OpenRTB Request"
+            ... // sparse OpenRTB Bid Request attributes
          }
       },
       "seller": {
@@ -393,7 +372,6 @@ The auctionSignals metadata may originate from diverse sources, so this map shou
             ...
          }
       }
-    "other entities providing metadata, as needed"
    }
    ...
 }
@@ -414,23 +392,23 @@ If buyer "https://dsp.example"’s igb.pbsmap is missing or 0, then the seller/S
 
 If the buyer opts into perBuyerSignals namespacing by returning pbsmap = 1, then the seller/SSP provides perBuyerSignalls as:
 
-```
+```jsonc
 "perBuyerSignals": {
 "https://dsp.example": {
         "buyer": …  // BidResponse.ext.igi[].igb[].pbs,
         "seller": {
            "ortb2":{
-                /* sparse ORTB value */
+               // sparse ORTB value
            }
         }
      }
 }
 
 {
-   "buyer": ...,   /* buyer’s pbs value as provided to the seller/publisher in BidResponse.ext.igi[].igb[].pbs */ 
+   "buyer": ...,   // buyer’s pbs value as provided to the seller/publisher in BidResponse.ext.igi[].igb[].pbs 
    "seller": {
       "ortb2": {
-         ...       /* buyer-specific BidRequest object values */ 
+         ...       // buyer-specific BidRequest object values
       } 
    }
 }

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -76,7 +76,7 @@ Must include at least a buyer object (`igb`, in the bid response from the buyer 
     <td><strong>Description</strong></td>
   </tr>
   <tr>
-    <td><code>origin </code></td>
+    <td><code>origin</code></td>
     <td>string; required</td>
     <td>Origin of the Interest Group buyer to participate in the IG auction. See https://developer.mozilla.org/en-US/docs/Glossary/Origin.</td>
   </tr>

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -141,26 +141,26 @@ The objects coming from sellers or publishers are expected to be ‘namespaced.�
 * If ortb2 namespace is used, it is expected that the structured request matches OpenRTB object model and definitions. All deviations should be done as extensions and negotiated apriori between the parties wanting to send/receive non-standard signals.  
 
 ## Object: InterestGroupAuctionBuyerSignals
-<table>
-  <tr>
-    <td><strong>Attribute</strong></td>
-    <td><strong>Type</strong></td>
-    <td><strong>Description</strong></td>
-  </tr>
-<tr>
-    <td><code>buyer</code></td>
-    <td>Any JSON serializable value</td>
-    <td>Canonical domain of the Interest Group owner as listed in <code>Object: InterestGroupAuctionIntent.igb.</code></td>
-  </tr>
-<tr>
-    <td><code>seller</code></td>
-    <td>object</td>
-    <td>Canonical domain of the Interest Group seller as listed in <code>Object: InterestGroupAuctionIntent.igs</code>
+Early PAAPI auction provisioning practice was for buyers to supply their perBuyerSignals to seller partners as a passthrough value <code>BidResponse.ext.igbid[].igbuyer[].buyerdata</code> or some other means. The seller places this in the buyer’s key in <code>auctionConfig.perBuyerSignals</code> and PA then provides the value as the perBuyerSignals parameter to generateBid.  This does not afford a clean way for the seller to provide signals to a specific buyer, such as Deals.
 
-If an ORTB object is present in both auctionSignals and this location, the fields in perBuyerSignals take precedence.
-</td>
-  </tr>
-</table>
+To accommodate this, the community extensions support a more open perBuyerSignals handling. In an OpenRTB BidRequest sellers can signal their ability to provide and in the BidResponse buyers may opt in to receive an InterestGroupAuctionBuyerSignals object in the interest group auction. 
+
+This object is a dictionary with support for some combination of the following enteries: 
+
+ ```javascript
+{
+   let signalsFromMyOrigin        = perBuyerSignals[browserSignals.interestGroupOwner]; 
+   let signalsFromComponentSeller = perBuyerSignals[browserSignals.seller];
+   let signalsFromTopLevelSeller  = perBuyerSignals[browserSignals.topLevelSeller];
+   let signalsFromPublisher       = perBuyerSignals[browserSignals.topWindowHostname];
+}
+```
+
+The presence and placement of these entries determine the role of the <a href="https://developer.mozilla.org/en-US/docs/Glossary/Origin">Origin</a> listed. 
+
+While the entities listed above and their associated <a href="https://developer.mozilla.org/en-US/docs/Glossary/Origin">Origins</a> are defined values established and recognized by the PA APIs, others may be included based on specific agreement between partners that have been negotiated <i>a priori</i>. In that case, the canonical domain of the parties should be used. 
+
+See Namespacing section of implementation guidance for additional detail https://github.com/hillslatt/examplefork/edit/hillslatt-ig-support-ext/extensions/community_extensions/Protected%20Audience%20Support.md?pr=%2FInteractiveAdvertisingBureau%2Fopenrtb%2Fpull%2F175#namespacing
 
 # Implementation Guidance
 

--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -38,7 +38,7 @@
 
 ## Object: InterestGroupAuctionIntent
 
-`BidResponse.ext.igi`: This extension to "Object: Bid" allows buyers and sellers to provide necessary signals in order to operate an Interest Group auction for a given ad slot. </br>
+`BidResponse.ext.igi`: This extension to "Object: BidResponse" allows buyers and sellers to provide necessary signals in order to operate an Interest Group auction for a given ad slot. </br>
 Must include at least one buyer (`igb`, in the bid response from the buyer to the seller) or at least one seller (`igs`, from the seller to the publisher) object, but not both.
 
 <table>


### PR DESCRIPTION
 **New**

- Section: Non-ORTB Signaling 
- Object: InterestGroupAuctionBuyerSignals
- Attributes: 
- - InterestGroupAuctionSupport.pbsmap
- - InterestGroupAuctionBuyer.pbsmap
- Additional Implementation Guidance for name spacing