### PR TITLE
Register Segtax for Permutive

### DIFF
--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -414,6 +414,10 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
       <td>Optable Data Collaboration Platform - Test Audiences</td>
     </tr>
     <tr>
+      <td>6000-6010</td>
+      <td>Permutive Standard Audiences</td>
+    </tr>
+    <tr>
       <td>103000</td>
       <td>
 	Audigent Warner Music Group Artists Taxonomy 1.0


### PR DESCRIPTION
This registers `segtax` IDs for Permutive's Standard Audiences.