### PR TITLE
Adding currency rejection scenario to seatnonbid

### DIFF
--- a/extensions/community_extensions/seat-non-bid.md
+++ b/extensions/community_extensions/seat-non-bid.md
@@ -296,6 +296,10 @@ There are many reasons for a non bid scenario and it is understood not all can b
       <td>Request Blocked - Privacy</td>
     </tr>
     <tr>
+      <td>205</td>
+      <td>Request Blocked - Unsupported Currency</td>
+    </tr>
+    <tr>
       <td>300</td>
       <td>Response Rejected - General</td>
     </tr>


### PR DESCRIPTION
Related to https://github.com/prebid/prebid-server/issues/3746

Prebid Server has a feature that lets bid adapters reject requests for currencies they can't support. It was proposed that we track this scenario with a specific seatnonbid. Proposing code 205.