### PR TITLE
Update OpenRTB v3.0 FINAL.md

### DIFF
--- a/OpenRTB v3.0 FINAL.md
+++ b/OpenRTB v3.0 FINAL.md
@@ -1069,7 +1069,7 @@ The following table lists the options for a bidder to signal the exchange as to 
   </tr>
   <tr>
     <td>500+</td>
-    <td>Exchange specific values; should be communicated with buyers beforehand.</td>
+    <td>Buyer specific values; should be communicated with exchanges beforehand.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
Fixing typo in No-Bid Reason table. Buyers respond with no-bid reasons, and therefore must communicate with exchanges the values they are able to return.