### PR TITLE
add buyer experiment group ID

### DIFF
--- a/extensions/community_extensions/Protected Audience Support.md
+++ b/extensions/community_extensions/Protected Audience Support.md
@@ -106,6 +106,12 @@ Must include at least a buyer object (`igb`, in the bid response from the buyer 
     <td>object</td>
     <td>The buyer’s priority signals, an object mapping string keys to Javascript numbers. If specified, the seller will add to its auction config <code>perBuyerPrioritySignals</code> attribute map, keyed by the Interest Group buyer origin. See https://github.com/WICG/turtledove/blob/main/FLEDGE.md#35-filtering-and-prioritizing-interest-groups </td>
   </tr>
+
+  <tr>
+    <td><code>begi</code></td>
+    <td>object</td>
+    <td>The buyer’s experiment group ID, an integer between zero and 65535 (16 bits). If specified, the seller will add to its auction config <code>perBuyerExperimentGroupIds</code> attribute map, keyed by the Interest Group buyer origin. See https://github.com/WICG/turtledove/blob/main/FLEDGE.md#21-initiating-an-on-device-auction </td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
Adding another parameter as part of igb, as there's another perBuyer* map that is part of a seller's auctionConfig that was missing.