### PR TITLE
Add Panxo AI-Audience Taxonomy 1.0 (panxo.ai) to the segment taxonomy registry

### DIFF
--- a/extensions/community_extensions/segtax.md
+++ b/extensions/community_extensions/segtax.md
@@ -182,6 +182,10 @@ Source : AdCOM [https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/maste
       <td>508</td>
       <td>Magnite Standard Audiences</td>
     </tr>
+    <tr>
+      <td>509</td>
+      <td>Panxo AI-Audience Taxonomy 1.0 - More info - <a href="https://specs.panxo.ai/taxonomy.html">https://specs.panxo.ai/taxonomy.html</a></td>
+    </tr>
 	<tr>
       <td>510</td>
   	<td>Titan Segments</td>


### PR DESCRIPTION
Registers vendor-specific segment taxonomy ID **509** for Panxo (panxo.ai).

**Taxonomy:** Panxo AI-Audience Taxonomy 1.0 - bot-filtered human audiences arriving at publisher sites via AI-assistant referrals (ChatGPT, Perplexity, Claude, Gemini, Copilot), segmented by referring assistant, inferred AI-search intent vertical, and recency.
**Documentation:** https://specs.panxo.ai/taxonomy.html
**Provider domain:** panxo.ai
**Contact:** agent@panxo.ai

ID 509 selected as the lowest unassigned vendor slot (registry currently skips from 508 to 510). Segment IDs travel as numeric values in `user.data` with `ext.segtax: 509`. Leaf additions within the reserved ranges will not require registry changes.